### PR TITLE
Improve interactions between module and imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2024-17-09
+
+### Added
+
+- Add supports for WebAssembly's Globals
+- Add `oninit` callback to custom module imports to know when the module is instatiated
+
+### Fixed
+
+- Fix a bug where the buffer sent from the sandbox was larger than expected
+- Fix a bug where the `task` might throws if the callback given wasn't returning a promise
+
+## [0.1.1] - 2024-12-02
+
 ### Added
 
 - Add initial commit
@@ -14,5 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/exu/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/dusk-network/exu/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/dusk-network/exu/releases/tag/v0.1.2
 [0.1.1]: https://github.com/dusk-network/exu/releases/tag/v0.1.1

--- a/src/mod.js
+++ b/src/mod.js
@@ -9,6 +9,7 @@
  *
  * @property {WebAssembly.Memory} memory - The WebAssembly memory object
  * @property {function} memcpy - The memory copy function
+ * @property {Object} globals - The WebAssembly's globals
  */
 
 /**
@@ -140,11 +141,15 @@ export class Module {
       const memory = await sandbox.memory;
       const exports = sandbox.exports;
       const memcpy = sandbox.memcpy;
-      const result = fn(exports, { memory: memory ?? MemoryProxy, memcpy });
+      const globals = await sandbox.globals;
 
-      result.finally(sandbox.terminate);
+      const result = fn(exports, {
+        memory: memory ?? MemoryProxy,
+        memcpy,
+        globals,
+      });
 
-      return await result;
+      return Promise.resolve(result).finally(sandbox.terminate);
     };
   }
 

--- a/tests/example/src/lib.rs
+++ b/tests/example/src/lib.rs
@@ -21,6 +21,9 @@ extern crate wee_alloc;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+#[no_mangle]
+pub static mut BUFFER: [u8; 64 * 1024] = [0; 64 * 1024];
+
 #[repr(transparent)]
 pub struct FatPtr(u64);
 
@@ -94,6 +97,20 @@ pub unsafe extern "C" fn fibonacci(n: u32) -> u32 {
 #[no_mangle]
 pub unsafe extern "C" fn endless_loop() {
     loop {}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn to_lower_case() {
+    let mut i = 0;
+
+    // Loop through BUFFER until we hit the null terminator
+    while i < BUFFER.len() && BUFFER[i] != 0 {
+        // If the character is an uppercase letter (A-Z), convert to lowercase
+        if BUFFER[i] >= b'A' && BUFFER[i] <= b'Z' {
+            BUFFER[i] = BUFFER[i] + (b'a' - b'A');
+        }
+        i += 1;
+    }
 }
 
 #[cfg(target_family = "wasm")]


### PR DESCRIPTION
- Add supports for WebAssembly's Globals
- Add `oninit` callback to custom module imports to know when the module is instatiated
- Fix a bug where the buffer sent from the sandbox was larger than expected