### PR TITLE
Improve JSR package score metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.2] - 2024-17-09
+## [0.1.3] - 2026-07-04
+
+### Added
+
+- Add public type declarations for the JSR entrypoint.
+
+### Changed
+
+- Include the README in published JSR package artifacts.
+- Update the README import example to use the JSR package specifier.
+
+## [0.1.2] - 2024-09-17
 
 ### Added
 
@@ -28,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/exu/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/dusk-network/exu/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/dusk-network/exu/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/dusk-network/exu/releases/tag/v0.1.2
 [0.1.1]: https://github.com/dusk-network/exu/releases/tag/v0.1.1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Exu is a high-performance library designed for both browser and Deno environment
 To include Exu in your project, import the module directly from the provided URL:
 
 ```javascript
-import { Module } from "path/to/exu/src/mod.js";
+import { Module } from "jsr:@dusk/exu";
 ```
 
 ### Basic Usage

--- a/deno.json
+++ b/deno.json
@@ -1,12 +1,12 @@
 {
   "name": "@dusk/exu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "exports": "./src/mod.js",
   "tasks": {
     "test": "deno test --allow-net --allow-read --allow-write --allow-run --allow-import"
   },
   "publish": {
-    "include": ["src"],
+    "include": ["LICENSE", "README.md", "src"],
     "exclude": ["src/tests"]
   }
 }

--- a/src/mod.d.ts
+++ b/src/mod.d.ts
@@ -1,0 +1,80 @@
+/**
+ * Run WebAssembly modules as isolated, abortable tasks in worker sandboxes.
+ *
+ * @module
+ */
+
+/**
+ * Values exposed to task callbacks for direct memory access.
+ */
+export interface MemoryAccessor {
+  /** The WebAssembly memory exported by the running module. */
+  memory: WebAssembly.Memory;
+  /** Copies bytes between JavaScript and WebAssembly memory. */
+  memcpy(
+    dest: number | Uint8Array | null,
+    source: number | Uint8Array,
+    count?: number,
+  ): Promise<void | Uint8Array>;
+  /** The WebAssembly globals exported by the running module. */
+  globals: WebAssembly.Exports;
+}
+
+/**
+ * Function executed against a freshly created WebAssembly sandbox.
+ */
+export type TaskCallback<T = unknown> = (
+  exports: WebAssembly.Exports,
+  accessor: MemoryAccessor,
+) => T | Promise<T>;
+
+/**
+ * Options used to construct a {@link Module}.
+ */
+export interface ModuleOptions {
+  /** WebAssembly module URL, fetch URL, or byte buffer. */
+  source: URL | string | Uint8Array;
+}
+
+/**
+ * Options used when creating a sandbox for a task or API call.
+ */
+export interface SandboxOptions {
+  /** Cancels the sandbox operation when aborted. */
+  signal?: AbortSignal;
+  /** Import module URL used while instantiating the WebAssembly module. */
+  imports?: URL | string;
+}
+
+/**
+ * Callable proxy over the WebAssembly module exports.
+ */
+export interface ModuleApi {
+  [name: string]: (...args: unknown[]) => Promise<unknown>;
+}
+
+/**
+ * WebAssembly module wrapper that runs each task in an isolated worker sandbox.
+ */
+export class Module {
+  /**
+   * Creates a module from a WebAssembly URL, fetch URL, byte buffer, or options object.
+   */
+  constructor(options: ModuleOptions | ModuleOptions["source"]);
+
+  /**
+   * Default import module URL used when a task does not provide one.
+   */
+  get defaultImports(): string | undefined;
+  set defaultImports(value: URL | string | undefined);
+
+  /**
+   * Creates an asynchronous task that runs in a fresh sandbox on every call.
+   */
+  task<T>(fn: TaskCallback<T>): (options?: SandboxOptions) => Promise<T>;
+
+  /**
+   * Returns a callable proxy for one-off WebAssembly export calls.
+   */
+  api(options?: SandboxOptions): ModuleApi;
+}

--- a/src/mod.js
+++ b/src/mod.js
@@ -3,6 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
+//
+// @ts-self-types="./mod.d.ts"
+
+/**
+ * Run WebAssembly modules as isolated, abortable tasks in worker sandboxes.
+ *
+ * @module
+ */
 
 /**
  * @typedef {Object} MemoryAccessor
@@ -164,9 +172,7 @@ export class Module {
    */
   api = (options = {}) =>
     new Proxy(NullTarget, {
-      get:
-        (_, prop) =>
-        (...args) =>
-          this.task((exports) => exports[prop](...args))(options),
+      get: (_, prop) => (...args) =>
+        this.task((exports) => exports[prop](...args))(options),
     });
 }


### PR DESCRIPTION
## Summary
- bump @dusk/exu to 0.1.3 for the next immutable JSR publish
- include README.md in the published package and update the README import example to use jsr:@dusk/exu
- add public declaration types and module docs to clear the JavaScript entrypoint slow-type score hit
- correct the invalid 0.1.2 changelog date using the v0.1.2 tag date

Resolves #7

## Verification
- deno fmt --check deno.json src/mod.js src/mod.d.ts
- deno publish --dry-run --allow-dirty
- npm audit --audit-level=low returns ENOLOCK because this Deno package has no npm lockfile
- controlecentrum review-pr https://github.com/dusk-network/exu/pull/6 --mode quick --blind: heuristic prompts only, no concrete finding
- controlecentrum review-pr https://github.com/dusk-network/exu/pull/6 --mode deep --blind --two-phase --budget-minutes 20 using GPT-5.5/xhigh: no validated material findings; non-blocking declaration/artifact proof obligations only
- deno test --allow-net --allow-read --allow-write --allow-run --allow-import currently fails on main too with: Promise resolution is still pending but the event loop has already resolved

## Notes
- JSR provenance/OIDC publishing is intentionally out of scope for this PR.
